### PR TITLE
Resetting HULK blind xss detection payload

### DIFF
--- a/xsstrike
+++ b/xsstrike
@@ -725,6 +725,8 @@ def initiator(url, GET, POST):
             print '%s Payload: %s' % (info, payload)
             webbrowser.open(url + param_data) # Opens the "injected" URL in browser
             next = raw_input('%s Press enter to execute next payload' % que)
+            #resetting payload
+            param_data = param_data.replace(payload, xsschecker)
     
     elif len(occur_number) == 0 and POST:
         choice = raw_input('%s Would you like to generate some payloads for blind XSS? [Y/n] ' % que).lower()


### PR DESCRIPTION
Hi There,
You need to reset the param_data, so the payload is correct when you try to open browser. Previously it show like this:

```
[!] Executing project HULK for blind XSS Detection
param before replace?email=d3v&code=121212/5
param after replace?email='"</Script><Html Onmouseover=(confirm)()//<imG/sRc=l oNerrOr=(prompt)() x>&code=121212/5
[!] Payload: '"</Script><Html Onmouseover=(confirm)()//<imG/sRc=l oNerrOr=(prompt)() x>
[?] Press enter to execute next payload
param before replace?email='"</Script><Html Onmouseover=(confirm)()//<imG/sRc=l oNerrOr=(prompt)() x>&code=121212/5
param replace?email='"</Script><Html Onmouseover=(confirm)()//<imG/sRc=l oNerrOr=(prompt)() x>&code=121212/5
[!] Payload: <!--<iMg sRc=--><img src=x oNERror=(prompt)`` x>
```
You can see, your replace is not working because it only search for `d3v` and that string already changed by first payload. So, whatever your payload, the program will forever looping first payload when  calling the browser.
```
webbrowser.open(url + param_data) # Opens the "injected" URL in browser
```

```
for payload in payloads:
            param_data = param_data.replace(xsschecker, payload) # Replaces the xsschecker with payload
            print '%s Payload: %s' % (info, payload)
            webbrowser.open(url + param_data) # Opens the "injected" URL in browser
            next = raw_input('%s Press enter to execute next payload' % que)
            #resetting payload
            param_data = param_data.replace(payload, xsschecker)
```
So, i think you need to reset param_data value :)

Thanks!
